### PR TITLE
Refactor CLI to use --input-path and --output-path options

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,4 +1,8 @@
+- Never start coding before approval on the design and implementation plan
 - Never commit and/or push before the user has tested your changes
+- Alway write tests for new features and bug fixes
+- Always check branch before writing any code, check if creating new branch is needed
+- use `gh` for all github operations
 - Always fix import issues, always fix all lint issues, always typecheck and fix type issues even in unrelated code
 - Please use function over class when possible
 - Please use f-strings over string concatenation
@@ -7,3 +11,6 @@
 - Always use uv for running commands
 - Focus on unix philosophy: do one thing and do it well
 - Always run ruff check and ruff format before committing
+- cleanup the dummy scripts from code before committing
+- use `uv run` for running scripts
+- do not write a lot of comments or docstrings, use docstrings when code is not self-explanatory

--- a/feature.txt
+++ b/feature.txt
@@ -1,0 +1,4 @@
+I want to build 
+
+1. output path as cli option
+2. Update prompts to use valid system prompt and user prompt

--- a/src/tiny/cli.py
+++ b/src/tiny/cli.py
@@ -12,15 +12,37 @@ from tiny.config import get_config
 console = Console()
 
 
-@click.command()
-@click.argument("note_file", type=click.Path(exists=True, path_type=Path))
-def cli(note_file: Path):
+@click.group()
+def cli():
+    """Tiny CLI tool for processing notes and posts."""
+    pass
+
+
+@cli.group()
+def write():
+    """Write commands for generating content."""
+    pass
+
+
+@write.command()
+@click.option(
+    "--input-path",
+    required=True,
+    type=click.Path(exists=True, path_type=Path),
+    help="Path to input note file",
+)
+@click.option(
+    "--output-path",
+    type=click.Path(path_type=Path),
+    help="Path to output post file (prints to stdout if not provided)",
+)
+def post(input_path: Path, output_path: Path | None):
     """Convert notes to posts."""
     config = get_config()
 
     console.print(
         Panel(
-            f"Processing note: [bold blue]{note_file}[/bold blue]",
+            f"Processing note: [bold blue]{input_path}[/bold blue]",
             title="Tiny Agent",
             border_style="blue",
         )
@@ -40,20 +62,22 @@ def cli(note_file: Path):
         task = progress.add_task("Reading note...", total=3)
 
         # Step 1: Read note
-        note_content = read_note_file(note_file)
+        note_content = read_note_file(input_path)
         progress.update(task, advance=1, description="Generating post content...")
 
         # Step 2: Generate post content
         llm_client = LLMClient(config)
         post_processor = PostProcessor(llm_client)
         post_content = post_processor.process_note(note_content)
-        progress.update(task, advance=1, description="Creating post file...")
+        progress.update(task, advance=1, description="Creating post...")
 
-        # Step 3: Write post file
+        # Step 3: Write post
         post_writer = PostWriter(config)
-        post_file_path = post_writer.write_post(post_content, note_file.name)
-        progress.update(task, advance=1, description="Complete!")
-
-        progress.update(task, advance=1)
-
-    console.print(f"[green]✓[/green] Successfully processed: {post_file_path}")
+        if output_path:
+            post_file_path = post_writer.write_post_to_file(post_content, output_path)
+            progress.update(task, advance=1, description="Complete!")
+            console.print(f"[green]✓[/green] Successfully processed: {post_file_path}")
+        else:
+            post_writer.write_post_to_stdout(post_content)
+            progress.update(task, advance=1, description="Complete!")
+            console.print("[green]✓[/green] Successfully processed to stdout")

--- a/src/tiny/config.py
+++ b/src/tiny/config.py
@@ -1,12 +1,9 @@
-from pathlib import Path
 from pydantic_settings import BaseSettings, SettingsConfigDict
+
 
 class TinyConfig(BaseSettings):
     model: str = "vertex_ai/gemini-2.5-flash"
-    
-    posts_dir: Path = Path("posts")
-    notes_dir: Path = Path("notes")
-    
+
     max_tokens: int = 2000
     temperature: float = 0.5
 
@@ -16,6 +13,7 @@ class TinyConfig(BaseSettings):
         case_sensitive=False,
         extra="allow",
     )
+
 
 def get_config() -> TinyConfig:
     return TinyConfig()

--- a/src/tiny/processors/post_writer.py
+++ b/src/tiny/processors/post_writer.py
@@ -1,6 +1,7 @@
 """Post writer for creating simple text files."""
 
 import logging
+import sys
 from pathlib import Path
 
 from tiny.ai.post_processor import PostContent
@@ -17,24 +18,49 @@ class PostWriter:
         """Initialize the post writer."""
         self.config = config
 
-    def write_post(self, post_content: PostContent, filename: str) -> Path:
+    def write_post_to_file(self, post_content: PostContent, output_path: Path) -> Path:
         """
-        Write a simple text file from post content.
+        Write a simple text file from post content to specified path.
 
         Args:
             post_content: Post content with title and content
+            output_path: Path where the post file should be written
 
         Returns:
             Path to the written file
         """
-        posts_dir = Path(self.config.posts_dir)
-        posts_dir.mkdir(parents=True, exist_ok=True)
-        file_path = posts_dir / filename
+        output_path.parent.mkdir(parents=True, exist_ok=True)
 
         text_content = f"{post_content.title}\n\n{post_content.content}"
 
-        with open(file_path, "w", encoding="utf-8") as f:
+        with open(output_path, "w", encoding="utf-8") as f:
             f.write(text_content)
 
-        logger.info(f"Written post file: {file_path}")
-        return file_path
+        logger.info(f"Written post file: {output_path}")
+        return output_path
+
+    def write_post_to_stdout(self, post_content: PostContent) -> None:
+        """
+        Write post content to stdout console.
+
+        Args:
+            post_content: Post content with title and content
+        """
+        text_content = f"{post_content.title}\n\n{post_content.content}"
+        print(text_content, file=sys.stdout)
+        logger.info("Written post to stdout")
+
+    def write_post(self, post_content: PostContent, filename: str) -> Path:
+        """
+        Legacy method for backward compatibility.
+        Write a simple text file from post content using current directory.
+
+        Args:
+            post_content: Post content with title and content
+            filename: Name of the file to write
+
+        Returns:
+            Path to the written file
+        """
+        file_path = Path(filename)
+        return self.write_post_to_file(post_content, file_path)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3,33 +3,113 @@ from tiny.cli import cli
 import tempfile
 from pathlib import Path
 
+
 class TestCLI:
     def test_main_help(self):
         runner = CliRunner()
         result = runner.invoke(cli, ["--help"])
 
         assert result.exit_code == 0
-        assert "Convert notes to posts" in result.output
+        assert "Tiny CLI tool for processing notes and posts" in result.output
+        assert "write" in result.output.lower()
 
-    def test_main_missing_file(self):
+    def test_write_help(self):
         runner = CliRunner()
-        result = runner.invoke(cli, ["nonexistent.md"])
+        result = runner.invoke(cli, ["write", "--help"])
+
+        assert result.exit_code == 0
+        assert "Write commands for generating content" in result.output
+        assert "post" in result.output.lower()
+
+    def test_write_post_help(self):
+        runner = CliRunner()
+        result = runner.invoke(cli, ["write", "post", "--help"])
+
+        assert result.exit_code == 0
+        assert "Convert notes to posts" in result.output
+        assert "--input-path" in result.output
+        assert "--output-path" in result.output
+        assert "required" in result.output
+
+    def test_write_post_missing_input_path(self):
+        runner = CliRunner()
+        result = runner.invoke(cli, ["write", "post"])
 
         assert result.exit_code != 0
-        assert "does not exist" in result.output
-        
-    def test_main_success(self):
+        assert "Missing option '--input-path'" in result.output
+
+    def test_write_post_nonexistent_input_file(self):
+        runner = CliRunner()
+        result = runner.invoke(cli, ["write", "post", "--input-path", "nonexistent.md"])
+
+        assert result.exit_code != 0
+        assert "does not exist" in result.output.lower()
+
+    def test_write_post_to_stdout(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp_path = Path(tmpdir)
+            note_file = tmp_path / "test_note.txt"
+            note_file.write_text("This is a test note content for stdout test.")
+
+            runner = CliRunner()
+            result = runner.invoke(
+                cli, ["write", "post", "--input-path", str(note_file)]
+            )
+
+            assert result.exit_code == 0
+            assert "Successfully processed to stdout" in result.output
+
+    def test_write_post_to_file(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp_path = Path(tmpdir)
+            note_file = tmp_path / "test_note.txt"
+            note_file.write_text("This is a test note content for file output test.")
+
+            output_file = tmp_path / "output_post.txt"
+
+            runner = CliRunner()
+            result = runner.invoke(
+                cli,
+                [
+                    "write",
+                    "post",
+                    "--input-path",
+                    str(note_file),
+                    "--output-path",
+                    str(output_file),
+                ],
+            )
+
+            assert result.exit_code == 0
+            assert "Successfully processed:" in result.output
+            assert str(output_file) in result.output
+            assert output_file.exists()
+
+            content = output_file.read_text()
+            assert len(content) > 0
+
+    def test_write_post_creates_output_directory(self):
         with tempfile.TemporaryDirectory() as tmpdir:
             tmp_path = Path(tmpdir)
             note_file = tmp_path / "test_note.txt"
             note_file.write_text("This is a test note content.")
 
+            output_dir = tmp_path / "nested" / "output"
+            output_file = output_dir / "post.txt"
+
             runner = CliRunner()
-            result = runner.invoke(cli, [str(note_file)])
+            result = runner.invoke(
+                cli,
+                [
+                    "write",
+                    "post",
+                    "--input-path",
+                    str(note_file),
+                    "--output-path",
+                    str(output_file),
+                ],
+            )
 
             assert result.exit_code == 0
-            assert "Successfully processed" in result.output
-            assert "test_note.txt" in result.output
-
-            post_file = Path("posts") / "test_note.txt"
-            assert post_file.exists()
+            assert output_dir.exists()
+            assert output_file.exists()


### PR DESCRIPTION
## Summary
- Refactored CLI from single argument to structured `tiny write post` subcommand with explicit options
- Added required `--input-path` option for input note files
- Added optional `--output-path` option (defaults to stdout if not provided)
- Removed environment directory dependencies (`posts_dir`, `notes_dir`)

## Test plan
- [x] All 8 new CLI tests pass
- [x] Help commands work correctly (`tiny --help`, `tiny write --help`, `tiny write post --help`)
- [x] Error handling: Missing `--input-path` throws proper error
- [x] Error handling: Non-existent input files throw proper error
- [x] File output: `--output-path` creates directories and writes files correctly
- [x] Stdout output: No `--output-path` outputs to console
- [x] Ruff checks pass, code formatted properly

## New Usage
```bash
# Write to file
tiny write post --input-path=notes/note.txt --output-path=posts/post.txt

# Write to stdout
tiny write post --input-path=notes/note.txt
```

## Breaking Changes
- Old CLI `tiny notes/note.txt` no longer works
- New CLI structure requires `write post` subcommands

Closes #10

🤖 Generated with [Claude Code](https://claude.ai/code)